### PR TITLE
add +1 back to UTCMonth

### DIFF
--- a/js/reading-list.js
+++ b/js/reading-list.js
@@ -48,7 +48,7 @@ function loadLists() {
             });
             function dateString(d) {
                 return d.getUTCFullYear().toString() + "/" +
-                    (d.getUTCMonth()).toString() + "/" +
+                    (d.getUTCMonth() + 1).toString() + "/" +
                     (d.getUTCDate()).toString();
             }
             var len = yaml.length;


### PR DESCRIPTION
With the +1 gone from month, the entire date shifts down a month. Adding the +1 back fixes it.